### PR TITLE
fix: remove "bun" export condition from all packages

### DIFF
--- a/.changeset/remove-bun-export-condition.md
+++ b/.changeset/remove-bun-export-condition.md
@@ -1,0 +1,7 @@
+---
+"@rolexjs/core": patch
+---
+
+Remove "bun" export condition from all packages
+
+The "bun" condition in exports pointed to ./src/index.ts which is not included in published npm packages, causing "Cannot find package" errors when consumed by bun runtime. All environments now use the compiled dist/ output.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "bun": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/local-platform/package.json
+++ b/packages/local-platform/package.json
@@ -8,7 +8,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "bun": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -23,7 +23,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "bun": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/prototype/package.json
+++ b/packages/prototype/package.json
@@ -23,7 +23,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "bun": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/rolexjs/package.json
+++ b/packages/rolexjs/package.json
@@ -25,7 +25,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "bun": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -24,7 +24,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "bun": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },


### PR DESCRIPTION
The "bun" condition pointed to ./src/index.ts which is not included in published npm packages, causing resolution failures in bun runtime.